### PR TITLE
Cherrypick very basic support for adding AARDFable

### DIFF
--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -17,4 +17,12 @@ module ActsAsRdfable
   end
 
   module_function :gem_root, :migration_path
+
+  def self.add_annotation_bindings!(instance)
+    instance.singleton_class.class_eval do
+      include ActsAsRdfable::ActsAsRdfableCore
+
+      acts_as_rdfable
+    end
+  end
 end


### PR DESCRIPTION
Introduces support for extending individual instances of unowned classes with support for the ActsAsRDFable readback API. Completely preliminary and may need to change if it ends up being awkward in use.

Intended usage here is that, given an instance of ActiveStorage::Blob or similar, which has annotations in the db:

```ruby
blob = ... #... some code returning an ActiveStorage::Blob
ActsAsRDFable.add_annotation_bindings!(blob)

# blob now responds to AARDFable methods:

blob.rdf_annotations
```

(I've ripped out support for overriding table name as that's more up in the air and quasi-nonfunctional right now)