### PR TITLE
Open Rails dependency up for Rails 6

### DIFF
--- a/acts_as_rdfable.gemspec
+++ b/acts_as_rdfable.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 5.2.3"
+  spec.add_dependency "rails", ">= 5.2.3"
 
   spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Similar to https://github.com/ualbertalib/oaisys/pull/26

Fixes this in jupiter:
```
Resolving dependencies....
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    rails (~> 6.0.2)

    acts_as_rdfable was resolved to 0.2.1, which depends on
      rails (~> 5.2.3)
```

Related to ualbertalib/jupiter#1430