### PR TITLE
OAI:DC & OAI:ETDMS Renderer and Presenter Support

### DIFF
--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -7,7 +7,6 @@ require 'acts_as_rdfable/rdf_annotation'
 require 'acts_as_rdfable/serializer'
 require 'acts_as_rdfable/serializers/oai_dc'
 require 'acts_as_rdfable/serializers/oai_etdms'
-require 'acts_as_rdfable/serializers/rdf_xml'
 
 module ActsAsRdfable
 
@@ -28,5 +27,9 @@ module ActsAsRdfable
 
       acts_as_rdfable formats: []
     end
+  end
+
+  def self.known_classes_for(format:)
+    ActsAsRdfable::Serializer.serializable_classes_for_format(format)
   end
 end

--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -4,6 +4,10 @@ require 'acts_as_rdfable/acts_as_rdfable_core'
 require 'acts_as_rdfable/migration_annotations'
 require 'acts_as_rdfable/active_record'
 require 'acts_as_rdfable/rdf_annotation'
+require 'acts_as_rdfable/serializer'
+require 'acts_as_rdfable/serializers/oai_dc'
+require 'acts_as_rdfable/serializers/oai_etdms'
+require 'acts_as_rdfable/serializers/rdf_xml'
 
 module ActsAsRdfable
 
@@ -18,11 +22,11 @@ module ActsAsRdfable
 
   module_function :gem_root, :migration_path
 
-  def self.add_annotation_bindings!(instance)
+  def self.add_annotation_bindings!(instance, formats: [])
     instance.singleton_class.class_eval do
       include ActsAsRdfable::ActsAsRdfableCore
 
-      acts_as_rdfable
+      acts_as_rdfable formats: []
     end
   end
 end

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -2,8 +2,12 @@ module ActsAsRdfable::ActsAsRdfableCore
   extend ActiveSupport::Concern
 
   class_methods do
-    def acts_as_rdfable(&configuration_block)
+    def acts_as_rdfable(formats: [])
       raise InvalidClassError unless self < ActiveRecord::Base
+      raise InvalidArgumentError unless (formats.is_a?(Symbol) || formats.is_a?(Array))
+
+      formats = [formats] if formats.is_a? Symbol
+      @aar_serialization_formats = formats
 
       define_method :rdf_annotations do
         self.singleton_class.rdf_annotations
@@ -13,12 +17,21 @@ module ActsAsRdfable::ActsAsRdfableCore
         self.singleton_class.rdf_annotation_for_attr attr
       end
 
+      define_method :serialize_metadata do |format:, into_document:|
+    #    raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
+        ActsAsRdfable::Serializer.serialize(instance: self, format: format, xml_doc: into_document)
+      end
+
       define_singleton_method :rdf_annotations do
         RdfAnnotation.for_table(self.table_name)
       end
 
       define_singleton_method :rdf_annotation_for_attr do |attr|
         RdfAnnotation.for_table_column(self.table_name, attr)
+      end
+
+      define_singleton_method :supported_metadata_serialization_formats do
+        @aar_serialization_formats || []
       end
 
     end

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -18,7 +18,9 @@ module ActsAsRdfable::ActsAsRdfableCore
       end
 
       define_method :serialize_metadata do |format:, into_document:|
-    #    raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
+        binding.pry
+        raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
+        format = format.to_sym unless format.is_a?(Symbol)
         ActsAsRdfable::Serializer.serialize(instance: self, format: format, xml_doc: into_document)
       end
 

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -7,7 +7,7 @@ module ActsAsRdfable::ActsAsRdfableCore
       raise InvalidArgumentError unless (formats.is_a?(Symbol) || formats.is_a?(Array))
 
       formats = [formats] if formats.is_a? Symbol
-      @aar_serialization_formats = formats
+      formats.each { |format| ActsAsRdfable::Serializer.register_format_for_class(self, format: format) }
 
       define_method :rdf_annotations do
         self.singleton_class.rdf_annotations
@@ -18,9 +18,8 @@ module ActsAsRdfable::ActsAsRdfableCore
       end
 
       define_method :serialize_metadata do |format:, into_document:|
-        binding.pry
-        raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
         format = format.to_sym unless format.is_a?(Symbol)
+        raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
         ActsAsRdfable::Serializer.serialize(instance: self, format: format, xml_doc: into_document)
       end
 
@@ -33,7 +32,7 @@ module ActsAsRdfable::ActsAsRdfableCore
       end
 
       define_singleton_method :supported_metadata_serialization_formats do
-        @aar_serialization_formats || []
+        formats
       end
 
     end

--- a/lib/acts_as_rdfable/serializer.rb
+++ b/lib/acts_as_rdfable/serializer.rb
@@ -28,12 +28,7 @@ module ActsAsRdfable
     def self.serialize(instance:, format:, xml_doc: )
       serializer = self.serializer_for(format)
       presenter = self.presenter_for(instance, format)
-
-#  support instantiating a doc here? I don't necessarily want to deal with larger declaration issues though...
-#      xml_doc = Builder::XmlMarkup.new unless xml_doc.present?
-
       serializer.serialize(presenter, xml: xml_doc)
-
     end
   end
 end

--- a/lib/acts_as_rdfable/serializer.rb
+++ b/lib/acts_as_rdfable/serializer.rb
@@ -1,0 +1,39 @@
+module ActsAsRdfable
+  module Serializer
+    def self.register_serializer(format:, serializer:)
+      @serializers ||= {}
+
+      @serializers[format] = serializer
+    end
+
+    def self.known_serializers
+      @serializers || {}
+    end
+
+    def self.serializer_for(format)
+      @serializers[format]
+    end
+
+    def self.presenter_for(instance, format)
+      @presenter_cache ||= {}
+      @presenter_cache[instance] ||= begin
+        klass_name = "Metadata::#{format.to_s.classify}::#{instance.class}Decorator"
+        klass = klass_name.constantize
+        klass.decorate(instance)
+      rescue NameError
+        raise NoSuchPresenter, "Metadata Decorator #{klass_name} is not defined for #{instance}"
+      end
+    end
+
+    def self.serialize(instance:, format:, xml_doc: )
+      serializer = self.serializer_for(format)
+      presenter = self.presenter_for(instance, format)
+
+#  support instantiating a doc here? I don't necessarily want to deal with larger declaration issues though...
+#      xml_doc = Builder::XmlMarkup.new unless xml_doc.present?
+
+      serializer.serialize(presenter, xml: xml_doc)
+
+    end
+  end
+end

--- a/lib/acts_as_rdfable/serializer.rb
+++ b/lib/acts_as_rdfable/serializer.rb
@@ -14,10 +14,26 @@ module ActsAsRdfable
       @serializers[format]
     end
 
+    def self.register_format_for_class(klass, format:)
+      format = format.to_sym if format.is_a?(String)
+
+      classes_for_format[format] ||= []
+      classes_for_format[format] << klass
+    end
+
+    def self.classes_for_format
+      @registered_class_formats ||= {}
+    end
+
+    def self.serializable_classes_for_format(format)
+      format = format.to_sym if format.is_a?(String)
+      classes_for_format[format] || []
+    end
+
     def self.presenter_for(instance, format)
       @presenter_cache ||= {}
       @presenter_cache[instance] ||= begin
-        klass_name = "Metadata::#{format.to_s.classify}::#{instance.class}Decorator"
+        klass_name = "Metadata::#{format.to_s.camelize}::#{instance.class}Decorator"
         klass = klass_name.constantize
         klass.decorate(instance)
       rescue NameError

--- a/lib/acts_as_rdfable/serializers/oai_dc.rb
+++ b/lib/acts_as_rdfable/serializers/oai_dc.rb
@@ -6,13 +6,14 @@ class OaiDc
              'xmlns:dc':'http://purl.org/dc/elements/1.1/',
              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
              'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd') do |oai|
-      oai.dc(:title, object.title) if object.title.present?
-      object.creator.each {|c| oai.dc :creator, c} if object.creator.present?
+
+      oai.dc(:title, object.title)
+      object.creator.each {|c| oai.dc :creator, c}
       object.contributor.each {|c| oai.dc :contributor, c} if object.contributor.present?
       oai.dc(:rights, object.rights) if object.rights.present?
-      oai.dc(:date, object.date) if object.date.present?
+      oai.dc(:date, object.date)
       oai.dc(:publisher, object.publisher) if object.publisher.present?
-      object.identifiers.each {|i| oai.dc :identifier, i} if object.identifiers.present?
+      object.identifiers.each {|i| oai.dc :identifier, i}
       object.subject.each {|s| oai.dc :subject, s} if object.subject.present?
       oai.dc(:description, object.description) if object.description.present?
       oai.dc(:type, object.type) if object.type.present?

--- a/lib/acts_as_rdfable/serializers/oai_dc.rb
+++ b/lib/acts_as_rdfable/serializers/oai_dc.rb
@@ -2,7 +2,6 @@ class OaiDc
   ActsAsRdfable::Serializer.register_serializer format: :oai_dc, serializer: self
 
   def self.serialize(object, xml:)
-
     xml.tag!('oai_dc:dc', 'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
              'xmlns:dc':'http://purl.org/dc/elements/1.1/',
              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',

--- a/lib/acts_as_rdfable/serializers/oai_dc.rb
+++ b/lib/acts_as_rdfable/serializers/oai_dc.rb
@@ -3,16 +3,21 @@ class OaiDc
 
   def self.serialize(object, xml:)
 
-    xml.tag!('oai_dc:dc') do |oai|
-      oai.dc :title, object.title
-      object.creator.each {|c| oai.dc :creator, c}
-      object.contributor.each {|c| oai.dc :contributor, c}
-      oai.dc :rights, object.rights
-      oai.dc :date, object.date
-      oai.dc :publisher, object.publisher
-      object.identifier.each {|i| oai.dc :identifier, i}
-      object.subject.each {|s| oai.dc :subject, s}
-      oai.dc :description, object.description
+    xml.tag!('oai_dc:dc', 'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+             'xmlns:dc':'http://purl.org/dc/elements/1.1/',
+             'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+             'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd') do |oai|
+      oai.dc(:title, object.title) if object.title.present?
+      object.creator.each {|c| oai.dc :creator, c} if object.creator.present?
+      object.contributor.each {|c| oai.dc :contributor, c} if object.contributor.present?
+      oai.dc(:rights, object.rights) if object.rights.present?
+      oai.dc(:date, object.date) if object.date.present?
+      oai.dc(:publisher, object.publisher) if object.publisher.present?
+      object.identifiers.each {|i| oai.dc :identifier, i} if object.identifiers.present?
+      object.subject.each {|s| oai.dc :subject, s} if object.subject.present?
+      oai.dc(:description, object.description) if object.description.present?
+      oai.dc(:type, object.type) if object.type.present?
+      object.languages.each {|l| oai.dc(:language, l) } if object.languages.present?
     end
   end
 end

--- a/lib/acts_as_rdfable/serializers/oai_dc.rb
+++ b/lib/acts_as_rdfable/serializers/oai_dc.rb
@@ -1,0 +1,18 @@
+class OaiDc
+  ActsAsRdfable::Serializer.register_serializer format: :oai_dc, serializer: self
+
+  def self.serialize(object, xml:)
+
+    xml.tag!('oai_dc:dc') do |oai|
+      oai.dc :title, object.title
+      object.creator.each {|c| oai.dc :creator, c}
+      object.contributor.each {|c| oai.dc :contributor, c}
+      oai.dc :rights, object.rights
+      oai.dc :date, object.date
+      oai.dc :publisher, object.publisher
+      object.identifier.each {|i| oai.dc :identifier, i}
+      object.subject.each {|s| oai.dc :subject, s}
+      oai.dc :description, object.description
+    end
+  end
+end

--- a/lib/acts_as_rdfable/serializers/oai_etdms.rb
+++ b/lib/acts_as_rdfable/serializers/oai_etdms.rb
@@ -1,0 +1,30 @@
+class OaiEtdms
+  ActsAsRdfable::Serializer.register_serializer format: :oai_etdms, serializer: self
+
+  def self.serialize(object, xml:)
+    xml.tag!('etd_ms:thesis', 'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
+             'xmlns:xsi2': 'http://www.w3.org/2001/XMLSchema-instance',
+             'xsi2:schemaLocation': 'http://www.ndltd.org/standards/metadata/etdms/1.0/ http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd') do |oai|
+
+      oai.etd_ms(:title, object.title)
+      oai.etd_ms(:creator, object.creator)
+      object.subject.each {|s| oai.etd_ms :subject, s} if object.subject.present?
+      oai.etd_ms(:description, object.description) if object.description.present?
+      object.contributor.each {|c| oai.etd_ms :contributor, c, role: 'advisor'} if object.contributor.present?
+      oai.etd_ms(:date, object.date)
+      oai.etd_ms(:type, object.type) if object.type.present?
+      object.identifiers.each {|i| oai.etd_ms :identifier, i}
+      oai.etd_ms(:language, object.language)  if object.language.present?
+      oai.etd_ms(:rights, object.rights) if object.rights.present?
+
+      if object.degree.present?
+        oai.etd_ms(:degree) do |degree|
+          degree.etd_ms(:name, object.degree)
+          degree.etd_ms(:level, object.degree_level) if object.degree_level.present?
+          degree.etd_ms(:discipline, object.discipline) if object.discipline.present?
+          degree.etd_ms(:grantor, object.institution) if object.institution.present?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

To support decoupling Oaisys' need for OAI:DC & OAI:ETDMS serializations of specific Jupiter models, and decoupling Jupiter from needing to know the specifics about serializaiton formats, ActsAsRDFable (which is increasing misnamed, so this will probably change soon)  is gaining support for generating serializations of these formats.

## Contents

- Adds a formats parameter to the model-level `acts_as_rdfable` DSL, so that models can indicate which serializations they intend to support.
- Adds a top-level Serialization abstraction that handles registration of models and the formats they intend to serialize into, obtaining presenters specific to a metadata format for registered classes, and renderers that handle the low-level detains of generating serializations of a presented model.
- Adds an OAI:DC renderer
- Adds an OAI:ETDMS renderer

## Not Included
- Support for querying all registered classes (necessary for the remaining optional ListMetadataFormats verb behaviour in Oaisys)
- N3 renderer (next-up)
- removal of the `add_annotation_bindings!` hack (will happen when the N3 renderer lands)
- tests (waiting to see if N3 support and the corresponding refactor of the code in Jupiter requires further changes to the API before I set it in stone by building tests around it)