### PR TITLE
Add a lookup for attribute given an rdf predicate

### DIFF
--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -36,7 +36,7 @@ module ActsAsRdfable::ActsAsRdfableCore
       end
 
       define_singleton_method :attribute_for_rdf_annotation do |annotation|
-        RdfAnnotation.find_by(table: self.table_name, predicate: annotation)&.column
+        RdfAnnotation.for_table_predicate(self.table_name, annotation)
       end
 
       define_singleton_method :supported_metadata_serialization_formats do

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -17,6 +17,10 @@ module ActsAsRdfable::ActsAsRdfableCore
         self.singleton_class.rdf_annotation_for_attr attr
       end
 
+      define_method :attribute_for_rdf_annotation do |annotation|
+        self.singleton_class.attribute_for_rdf_annotation annotation
+      end
+
       define_method :serialize_metadata do |format:, into_document:|
         format = format.to_sym unless format.is_a?(Symbol)
         raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
@@ -29,6 +33,10 @@ module ActsAsRdfable::ActsAsRdfableCore
 
       define_singleton_method :rdf_annotation_for_attr do |attr|
         RdfAnnotation.for_table_column(self.table_name, attr)
+      end
+
+      define_singleton_method :attribute_for_rdf_annotation do |annotation|
+        RdfAnnotation.find_by(table: self.table_name, predicate: annotation)&.column
       end
 
       define_singleton_method :supported_metadata_serialization_formats do

--- a/lib/acts_as_rdfable/rdf_annotation.rb
+++ b/lib/acts_as_rdfable/rdf_annotation.rb
@@ -5,4 +5,5 @@ class RdfAnnotation < ActiveRecord::Base
 
   scope :for_table, ->(table_name) { where(table: table_name) }
   scope :for_table_column, ->(table_name, column_name) { for_table(table_name).where(column: column_name) }
+  scope :for_table_predicate, ->(table_name, predicate_name) { for_table(table_name).where(predicate: predicate_name) }
 end


### PR DESCRIPTION
In an ingest script I was reading metadata from a graph of triples and needed to derive the attribute name from the predicate describing the data.  After some misunderstanding (`rdf_annotation_for_attr` will find the predicate given the attribute) we discovered that this wasn't something we'd thought about.  So here it is!

Usage: `instance.attribute_for_rdf_annotation(predicate)`