### PR TITLE
Modify to help us with seeding and testing our application

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Or install it yourself as:
 $ gem install acts_as_rdfable
 ```
 
+## Configuring ActsAsRdfable
+You can configure the following default values by overriding these values using `ActsAsRdfable.configure` method.
+```
+dump_changes      # false by default
+dump_to_path      # 'db/seeds/rdf_annotations.rb' by default
+```
+
 ## Contributing
 Contribution directions go here.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can configure the following default values by overriding these values using 
 dump_changes      # false by default
 dump_to_path      # 'db/seeds/rdf_annotations.rb' by default
 ```
+There's a handy generator that generates the default configuration file into config/initializers directory. Run the following generator command, then edit the generated file.
+```
+% rails g acts_as_rdfable:config
+```
 
 ## Contributing
 Contribution directions go here.

--- a/acts_as_rdfable.gemspec
+++ b/acts_as_rdfable.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 5.2.3"
+  spec.add_dependency "seed_dump", '~> 3.3', '>= 3.3.1'
 
   spec.add_development_dependency "sqlite3"
 end

--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'acts_as_rdfable/config'
 require "acts_as_rdfable/railtie"
 require 'acts_as_rdfable/acts_as_rdfable_core'
 require 'acts_as_rdfable/migration_annotations'

--- a/lib/acts_as_rdfable/config.rb
+++ b/lib/acts_as_rdfable/config.rb
@@ -1,0 +1,25 @@
+module ActsAsRdfable
+    # Configures global settings for ActsAsRdfable
+    #   ActsAsRdfable.configure do |config|
+    #     config.dump_changes = false
+    #     config.dump_to_path = 'db/seeds/rdf_annotations.rb'
+    #   end
+    class << self
+      def configure
+        yield config
+      end
+  
+      def config
+        @_config ||= Config.new
+      end
+    end
+  
+    class Config
+      attr_accessor :dump_changes, :dump_to_path
+  
+      def initialize
+        @dump_changes = false
+        @dump_to_path = 'db/seeds/rdf_annotations.rb'
+      end
+    end
+  end

--- a/lib/acts_as_rdfable/migration_annotations.rb
+++ b/lib/acts_as_rdfable/migration_annotations.rb
@@ -73,6 +73,6 @@ module ActsAsRdfable::MigrationAnnotations
   end
 
   def dump_rdf_annotations
-    ::SeedDump.dump(RdfAnnotation, file: 'db/seeds/rdf_annotations.rb')
+    SeedDump.dump(RdfAnnotation, file: ActsAsRdfable.config.dump_to_path) if ActsAsRdfable.config.dump_changes
   end
 end

--- a/lib/acts_as_rdfable/migration_annotations.rb
+++ b/lib/acts_as_rdfable/migration_annotations.rb
@@ -1,3 +1,5 @@
+require 'seed_dump'
+
 module ActsAsRdfable::MigrationAnnotations
   extend ActiveSupport::Concern
 
@@ -28,11 +30,15 @@ module ActsAsRdfable::MigrationAnnotations
       annotation.predicate = rdf_predicate.to_s
       annotation.save!
     end
+
+    dump_rdf_annotations
   end
 
   def remove_rdf_table_annotations(table)
     irreversible! %Q(Cannot reverse deletion of RDF annotations for table "#{table}")
     delete_table_annotations(table)
+
+    dump_rdf_annotations
   end
 
   def add_rdf_column_annotation(table, column, has_predicate:)
@@ -41,11 +47,15 @@ module ActsAsRdfable::MigrationAnnotations
     annotation = RdfAnnotation.for_table(table).find_or_initialize_by(column: column)
     annotation.predicate = has_predicate.to_s
     annotation.save!
+
+    dump_rdf_annotations
   end
 
   def remove_rdf_column_annotation(table, column)
     irreversible! %Q(Cannot reverse deletion of RDF annotations for "#{table}"."#{column}")
     delete_column_annotation(table, column)
+
+    dump_rdf_annotations
   end
 
   private
@@ -60,5 +70,9 @@ module ActsAsRdfable::MigrationAnnotations
 
   def irreversible!(msg)
     raise ActiveRecord::IrreversibleMigration, msg if reverting?
+  end
+
+  def dump_rdf_annotations
+    ::SeedDump.dump(RdfAnnotation, file: 'db/seeds/rdf_annotations.rb')
   end
 end

--- a/lib/generators/acts_as_rdfable/USAGE
+++ b/lib/generators/acts_as_rdfable/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Copies ActsAsRdfable configuration file to your application's initializer directory.
+
+Example:
+    rails g acts_as_rdfable:config
+
+    This will create:
+        config/initializers/acts_as_rdfable.rb

--- a/lib/generators/acts_as_rdfable/config_generator.rb
+++ b/lib/generators/acts_as_rdfable/config_generator.rb
@@ -1,0 +1,14 @@
+module ActsAsRdfable
+  module Generators
+    # rails g acts_as_rdfable:config
+    class ConfigGenerator < Rails::Generators::Base # :nodoc:
+      source_root File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+
+      desc "Copies ActsAsRdfable configuration file to your application's initializer directory."
+
+      def copy_config_file
+        template 'acts_as_rdfable_template.rb', 'config/initializers/acts_as_rdfable.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/acts_as_rdfable/templates/acts_as_rdfable_template.rb
+++ b/lib/generators/acts_as_rdfable/templates/acts_as_rdfable_template.rb
@@ -1,0 +1,5 @@
+ActsAsRdfable.configure do |config|
+  # config.dump_changes = false
+  # config.dump_to_path = 'db/seeds/rdf_annotations.rb'
+end
+  


### PR DESCRIPTION
Any of the add/remove/delete methods in ActsAsRdfable::MigrationAnnotations::RdfConfig could create/update a db/seeds/rdf_annotations.rb file in our application (maybe seed_dump) with the current dump of the database.

We could check this in along with our db/schema.rb. Then load it from our db/seeds.rb to faciliate with database setup and tests.

https://github.com/ualbertalib/acts_as_rdfable/issues/12