### PR TITLE
Use `.class` instead of `.singleton_class` due to issue with Rails 7

### DIFF
--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -23,7 +23,7 @@ module ActsAsRdfable
   module_function :gem_root, :migration_path
 
   def self.add_annotation_bindings!(instance, formats: [])
-    instance.singleton_class.class_eval do
+    instance.class.class_eval do
       include ActsAsRdfable::ActsAsRdfableCore
 
       acts_as_rdfable formats: []

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -10,20 +10,20 @@ module ActsAsRdfable::ActsAsRdfableCore
       formats.each { |format| ActsAsRdfable::Serializer.register_format_for_class(self, format: format) }
 
       define_method :rdf_annotations do
-        self.singleton_class.rdf_annotations
+        self.class.rdf_annotations
       end
 
       define_method :rdf_annotation_for_attr do |attr|
-        self.singleton_class.rdf_annotation_for_attr attr
+        self.class.rdf_annotation_for_attr attr
       end
 
       define_method :attribute_for_rdf_annotation do |annotation|
-        self.singleton_class.attribute_for_rdf_annotation annotation
+        self.class.attribute_for_rdf_annotation annotation
       end
 
       define_method :serialize_metadata do |format:, into_document:|
         format = format.to_sym unless format.is_a?(Symbol)
-        raise InvalidArgumentError unless self.singleton_class.supported_metadata_serialization_formats.include?(format)
+        raise InvalidArgumentError unless self.class.supported_metadata_serialization_formats.include?(format)
         ActsAsRdfable::Serializer.serialize(instance: self, format: format, xml_doc: into_document)
       end
 


### PR DESCRIPTION
From the Rails 7 upgrade in Jupiter, this gem is causing issues due to a change in how `.singleton_class` works:

https://github.com/ualbertalib/jupiter/pull/3250#issuecomment-1755980677

> Tests are failing due to ActsAsRDF gem. We are seeing errors like this:
> ```
> /Users/murny/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/model_schema.rb:633:in `compute_table_name': undefined method `table_name' for nil:NilClass (NoMethodError)
> 
>             base_class.table_name
>                       ^^^^^^^^^^^
> 	from /Users/murny/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/model_schema.rb:284:in `reset_table_name'
> 	from /Users/murny/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/model_schema.rb:248:in `table_name'
> 	from /Users/murny/jupiter/app/services/rdf_graph_creation_service.rb:5:in `get_prefixed_predicates'
> ```	
> 
> I believe the issue from troubleshooting is due to the way we were relying on `singleton_class` in this gem to get the "class" of the model.  It appears something broke in a newer version in Rails where the `singleton_class` no longer returns the correct data back.
> 
> I believe this is related to this issue which was closed with no action:
> https://github.com/rails/rails/issues/38293. 
> Which is where the `singleton_class` no longer responds to `.inspect` with a similar error.
> 
> A simple solution is just use `self.class` instead of `self.singleton_class` for getting the models class. Will have to investigate if theirs any side effects from making this change.
> 
> Also feel like this gem could be improved. We have multiple ways to "register" the gem into models, not sure why we have many ways? (Activerecord base include and `add_annotation_bindings!` etc)

So as mentioned, we can just use `.class` instead of `.singleton_class` to  fix this issue with how `.singleton_class` is now working in Rails 7.

This is the minimal amount of changes required to fix this issue for Rails 7 in Jupiter. I manually tested every method that could have been affected with this change inside `acts_as_rdfable_core.rb` and `acts_as_rdfable.rb`. Everything is working as intended.

This gem needs love though:
- Zero documentation about what this gem does or how it works.
- Test runner does not even work, completely broken.
- No tests at all
- Running old Ruby version
- No linters and no CI
- We are not pushing this up as a real gem?
- Much of the code in this gem seems unused in Jupiter/OAISYS (not familiar with ActsAsRDF though)?
- We are mounting ActsAsRDF multiple times in Jupiter? Once via including ActsAsRDF into ActiveRecord::Base and many times on runtime via `add_annotation_bindings!` on EntitiesController/RdfGraphCreationService?
- The way we create the ActsAsRDF DSL seems odd, and reason for this bug that this PR is trying to fix. We shouldn't need to metaprogram these methods in when you put `acts_as_rdf` in a model 🤔 
- No Changelog
- Version in `version.rb` is wrong compared to latest tag (v0.2.1 vs v0.4.0)