### PR TITLE
Bump version file to v0.5.0

### DIFF
--- a/lib/acts_as_rdfable/version.rb
+++ b/lib/acts_as_rdfable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsRdfable
-  VERSION = '0.2.1'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
Looks like we haven't been doing this, going to bump this version to v0.5.0 (we technically on v0.4.0 right now).

After this gets merged, I'll create a tag for this new version